### PR TITLE
fix: resolve tag formatting issue when pushing to ACR

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -101,10 +101,15 @@ jobs:
           login-server: https://${{ vars.REGISTRY_ADDRESS }}
           username: "${{ vars.REGISTRY_USERNAME }}"
           password: "${{ secrets.REGISTRY_PASSWORD }}"
-      - name: Build and push
-        run: |
-          docker build -t ${{ vars.REGISTRY_ADDRESS }}/${{ vars.REGISTRY_NAMESPACE }}/${{ vars.IMAGE_NAME }}:${{ steps.meta.outputs.tags }} ./packages/frontend
-          docker push ${{ vars.REGISTRY_ADDRESS }}/${{ vars.REGISTRY_NAMESPACE }}/${{ vars.IMAGE_NAME }}:${{ steps.meta.outputs.tags }}
+      - name: Build and push to ACR
+        uses: docker/build-push-action@v5
+        with:
+          context: ./packages/frontend
+          file: ./packages/frontend/dockerfile
+          push: true
+          tags: |
+            ${{ vars.REGISTRY_ADDRESS }}/${{ vars.REGISTRY_NAMESPACE }}/vastsea-sso-frontend:${{ steps.meta.outputs.version }}
+            ${{ vars.REGISTRY_ADDRESS }}/${{ vars.REGISTRY_NAMESPACE }}/vastsea-sso-frontend:latest
 
   build_docker_backend_acr:
     name: Build Docker Backend ACR
@@ -127,10 +132,16 @@ jobs:
           login-server: https://${{ vars.REGISTRY_ADDRESS }}
           username: "${{ vars.REGISTRY_USERNAME }}"
           password: "${{ secrets.REGISTRY_PASSWORD }}"
-      - name: Build and push
-        run: |
-          docker build -t ${{ vars.REGISTRY_ADDRESS }}/${{ vars.REGISTRY_NAMESPACE }}/${{ vars.IMAGE_NAME }}:${{ steps.meta.outputs.tags }} ./packages/backend
-          docker push ${{ vars.REGISTRY_ADDRESS }}/${{ vars.REGISTRY_NAMESPACE }}/${{ vars.IMAGE_NAME }}:${{ steps.meta.outputs.tags }}
+      - name: Build and push to ACR
+        uses: docker/build-push-action@v5
+        with:
+          context: ./packages/backend
+          file: ./packages/backend/dockerfile
+          push: true
+          tags: |
+            ${{ vars.REGISTRY_ADDRESS }}/${{ vars.REGISTRY_NAMESPACE }}/vastsea-sso-backend:${{ steps.meta.outputs.version }}
+            ${{ vars.REGISTRY_ADDRESS }}/${{ vars.REGISTRY_NAMESPACE }}/vastsea-sso-backend:latest
+
   deploy:
     name: Deploy
     needs: [build_docker_frontend, build_docker_backend, build_docker_frontend_acr, build_docker_backend_acr]


### PR DESCRIPTION
## What’s fixed

This PR fixes an issue during image push to Aliyun ACR where `${{ steps.meta.outputs.tags }}` may contain multiple tags. This caused `docker build -t` and `docker push` to fail due to incorrect formatting. The script is now updated to iterate and push each tag individually.
