### PR TITLE
fix(docker): correct frontend dockerfile build issues

### DIFF
--- a/packages/frontend/dockerfile
+++ b/packages/frontend/dockerfile
@@ -3,8 +3,8 @@ WORKDIR /app
 
 ADD . .
 
-ENV BASE_URL "/api"
-ENV AUTH_SERVER_CLIENT_ID ""
+ENV BASE_URL="/api"
+ENV AUTH_SERVER_CLIENT_ID=""
 
 RUN npm i -g pnpm && \
     cd packages/frontend && \
@@ -13,6 +13,6 @@ RUN npm i -g pnpm && \
 
 FROM nginx AS runner
 
-COPY --from=builder /app/dist /usr/share/nginx/html
+COPY --from=builder /app/packages/frontend/dist /usr/share/nginx/html
 
 EXPOSE 80


### PR DESCRIPTION
This pull request makes updates to the `packages/frontend/dockerfile` to improve environment variable formatting and fix the build process for the frontend application. 

Environment variable formatting:

* Updated the `ENV` declarations to remove unnecessary spaces around `=` for `BASE_URL` and `AUTH_SERVER_CLIENT_ID`, ensuring consistency and avoiding potential parsing issues.

Build process fix:

* Adjusted the `COPY` command to correctly reference the `dist` directory under `packages/frontend`, ensuring the frontend build artifacts are properly copied to the Nginx container.