### PR TITLE
chore: removed unused references

### DIFF
--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -8,8 +8,6 @@ import { join } from 'path';
 import 'winston-daily-rotate-file';
 import * as winston from 'winston';
 import { utilities, WinstonModule } from 'nest-winston';
-import { windowTime } from 'rxjs';
-import { FileTypeValidator } from '@nestjs/common';
 
 const CONSOLE_TRANSPORT = new winston.transports.Console({
   format: winston.format.combine(


### PR DESCRIPTION
This pull request includes a small change to the `packages/backend/src/main.ts` file. The change removes unused imports, specifically `windowTime` from `rxjs` and `FileTypeValidator` from `@nestjs/common`, to clean up the code.